### PR TITLE
Add API for category slug products

### DIFF
--- a/src/app/api/category/[slug]/route.js
+++ b/src/app/api/category/[slug]/route.js
@@ -1,0 +1,15 @@
+import { connectDB } from '@/lib/mongodb';
+import Product from '@/models/Product';
+import { NextResponse } from 'next/server';
+
+export async function GET(_, { params }) {
+  await connectDB();
+  const { slug } = params;
+
+  if (!slug) {
+    return NextResponse.json({ error: 'slug parametresi gerekli' }, { status: 400 });
+  }
+
+  const products = await Product.find({ category_slug: slug }).sort({ price: 1 });
+  return NextResponse.json(products);
+}


### PR DESCRIPTION
## Summary
- implement `/api/category/[slug]` endpoint to query `Product` by category slug

## Testing
- `npm run lint` (fails: many pre-existing warnings and errors)


------
https://chatgpt.com/codex/tasks/task_e_6840604d9ce483329e005a37c93f4911