### PR TITLE
Refactor API routes with shared helpers

### DIFF
--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -1,11 +1,10 @@
-import { connectDB } from '@/lib/mongodb';
 import User from '@/models/User';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import { withDB } from '@/lib/api-utils';
 
-export async function POST(req) {
+export const POST = withDB(async (req) => {
   try {
-    await connectDB();
 
     const { email, password } = await req.json();
 
@@ -42,4 +41,4 @@ export async function POST(req) {
     console.error('LOGIN ERROR:', err);
     return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 });
   }
-}
+});

--- a/src/app/api/auth/register/route.js
+++ b/src/app/api/auth/register/route.js
@@ -1,11 +1,10 @@
-import { connectDB } from '@/lib/mongodb';
 import User from '@/models/User';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
+import { withDB } from '@/lib/api-utils';
 
-export async function POST(req) {
+export const POST = withDB(async (req) => {
   try {
-    await connectDB();
 
     const body = await req.json();
 
@@ -48,4 +47,4 @@ export async function POST(req) {
       status: 500,
     });
   }
-}
+});

--- a/src/app/api/brands/route.js
+++ b/src/app/api/brands/route.js
@@ -1,10 +1,9 @@
 //api/brands/route.js
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await connectDB();
+export const GET = withDB(async () => {
 
   const pipeline = [
     {
@@ -60,4 +59,4 @@ export async function GET() {
 
   const result = await Product.aggregate(pipeline);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/business/route.js
+++ b/src/app/api/business/route.js
@@ -1,12 +1,11 @@
 // GET /api/business?name=Fıstık%20Bilgisayar
 
-import { connectDB } from '@/lib/mongodb';
 import Business from '@/models/Business';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const name = searchParams.get('name');
 
@@ -27,4 +26,4 @@ export async function GET(req) {
     coordinates: business.location.coordinates,
     productCount
   });
-}
+});

--- a/src/app/api/businesses/route.js
+++ b/src/app/api/businesses/route.js
@@ -1,11 +1,10 @@
 // GET /api/businesses?lat=...&lng=...&radius=...
 
-import { connectDB } from '@/lib/mongodb';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
 
   const lat = parseFloat(searchParams.get('lat'));
@@ -36,4 +35,4 @@ export async function GET(req) {
 
   const all = await Business.find({}, { _id: 0, name: 1, website: 1 });
   return NextResponse.json(all);
-}
+});

--- a/src/app/api/categories/menu/route.js
+++ b/src/app/api/categories/menu/route.js
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
-import mongoose from 'mongoose';
 import Category from '@/models/Category';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await mongoose.connect(process.env.MONGO_URI);
+export const GET = withDB(async () => {
 
   const categories = await Category.find();
 
@@ -30,4 +29,4 @@ export async function GET() {
   }));
 
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/categories/route.js
+++ b/src/app/api/categories/route.js
@@ -1,11 +1,10 @@
 ///api/categories/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const type = searchParams.get('type');
 
@@ -24,7 +23,7 @@ export async function GET(req) {
 
   const categories = await Product.distinct('main_category');
   return NextResponse.json(categories);
-}
+});
 
 
 /*import { connectDB } from '@/lib/mongodb';

--- a/src/app/api/category/[slug]/route.js
+++ b/src/app/api/category/[slug]/route.js
@@ -1,9 +1,8 @@
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(_, { params }) {
-  await connectDB();
+export const GET = withDB(async (_, { params }) => {
   const { slug } = params;
 
   if (!slug) {
@@ -12,4 +11,4 @@ export async function GET(_, { params }) {
 
   const products = await Product.find({ category_slug: slug }).sort({ price: 1 });
   return NextResponse.json(products);
-}
+});

--- a/src/app/api/features/route.js
+++ b/src/app/api/features/route.js
@@ -1,10 +1,9 @@
 //api/features/route.js
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await connectDB();
+export const GET = withDB(async () => {
 
   const pipeline = [
     {
@@ -33,4 +32,4 @@ export async function GET() {
 
   const result = await Product.aggregate(pipeline);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/filter-meta/route.js
+++ b/src/app/api/filter-meta/route.js
@@ -1,22 +1,12 @@
 // 📁 /api/filter-meta/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
-
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
-  const filters = {};
-
-  // Filtre parametrelerini oku
-  if (searchParams.get('main')) filters.main_category = searchParams.get('main');
-  if (searchParams.get('sub')) filters.subcategory = searchParams.get('sub');
-  if (searchParams.get('item')) filters.category_item = searchParams.get('item');
-  if (searchParams.get('brand')) filters.brand = searchParams.get('brand');
-  if (searchParams.get('category_slug')) filters.category_slug = searchParams.get('category_slug');
-  if (searchParams.get('group_slug')) filters.group_slug = searchParams.get('group_slug');
+  const filters = getFiltersFromQuery(searchParams);
 
   const pipeline = [
     { $match: filters },
@@ -68,4 +58,4 @@ export async function GET(req) {
     maxPrice: data.priceRange[0]?.maxPrice || 0,
     businessCount: data.businessCount[0]?.count || 0
   });
-}
+});

--- a/src/app/api/filters/route.js
+++ b/src/app/api/filters/route.js
@@ -1,12 +1,11 @@
 // GET /api/filters
 // Açıklama: Tüm filtre verilerini (kategori hiyerarşisi, markalar, özellikler) tek JSON içinde döner.
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await connectDB();
+export const GET = withDB(async () => {
 
   // ✅ Kategori Hiyerarşisi
   const categoryPipeline = [
@@ -88,4 +87,4 @@ export async function GET() {
     brands,
     features
   });
-}
+});

--- a/src/app/api/group/[slug]/comparison/route.js
+++ b/src/app/api/group/[slug]/comparison/route.js
@@ -1,11 +1,10 @@
 // src/app/api/group/[slug]/comparison/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(_, { params }) {
-  await connectDB();
+export const GET = withDB(async (_, { params }) => {
   const { slug } = params;
 
   const products = await Product.find({ group_slug: slug });
@@ -34,4 +33,4 @@ export async function GET(_, { params }) {
   };
 
   return NextResponse.json(response);
-}
+});

--- a/src/app/api/group/[slug]/route.js
+++ b/src/app/api/group/[slug]/route.js
@@ -1,14 +1,13 @@
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
 import { getGroup } from '@/lib/group';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req, { params }) {
-  await connectDB();
+export const GET = withDB(async (req, { params }) => {
   const slug = params.slug;
   const { searchParams } = new URL(req.url);
   const id = searchParams.get('id');
 
   const { status, body } = await getGroup({ slug, id, Product });
   return NextResponse.json(body, { status });
-}
+});

--- a/src/app/api/group/route.js
+++ b/src/app/api/group/route.js
@@ -1,14 +1,13 @@
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
 import { getGroup } from '@/lib/group';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('slug');
   const id = searchParams.get('id');
 
   const { status, body } = await getGroup({ slug, id, Product });
   return NextResponse.json(body, { status });
-}
+});

--- a/src/app/api/grouped-by-category/route.js
+++ b/src/app/api/grouped-by-category/route.js
@@ -1,9 +1,8 @@
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await connectDB();
+export const GET = withDB(async () => {
 
   const categories = await Product.aggregate([
     {
@@ -27,4 +26,4 @@ export async function GET() {
   ]);
 
   return Response.json(categories);
-}
+});

--- a/src/app/api/grouped-products/route.js
+++ b/src/app/api/grouped-products/route.js
@@ -1,20 +1,12 @@
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
 
   // Filtreleri al
-  const filters = {};
-  if (searchParams.get('main')) filters.main_category = searchParams.get('main');
-  if (searchParams.get('sub')) filters.subcategory = searchParams.get('sub');
-  if (searchParams.get('item')) filters.category_item = searchParams.get('item');
-  if (searchParams.get('brand')) filters.brand = searchParams.get('brand');
-  if (searchParams.get('category_slug')) filters.category_slug = searchParams.get('category_slug');
-  if (searchParams.get('group_slug')) filters.group_slug = searchParams.get('group_slug');
-  if (searchParams.get('q')) filters.group_title = { $regex: searchParams.get('q'), $options: 'i' };
+  const filters = getFiltersFromQuery(searchParams);
 
   let sortStage = {};
   const sort = searchParams.get('sort');
@@ -53,4 +45,4 @@ export async function GET(req) {
 
   const result = await Product.aggregate(pipeline);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/groups/route.js
+++ b/src/app/api/groups/route.js
@@ -1,23 +1,15 @@
 // GET /api/groups?main=&sub=&item=&brand=&category_slug=&group_slug=&q=&sort=&lat=&lng=&radius=
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
+import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
 
   // FİLTRELER
-  const filters = {};
-  if (searchParams.get('main')) filters.main_category = searchParams.get('main');
-  if (searchParams.get('sub')) filters.subcategory = searchParams.get('sub');
-  if (searchParams.get('item')) filters.category_item = searchParams.get('item');
-  if (searchParams.get('brand')) filters.brand = searchParams.get('brand');
-  if (searchParams.get('category_slug')) filters.category_slug = searchParams.get('category_slug');
-  if (searchParams.get('group_slug')) filters.group_slug = searchParams.get('group_slug');
-  if (searchParams.get('q')) filters.group_title = { $regex: searchParams.get('q'), $options: 'i' };
+  const filters = getFiltersFromQuery(searchParams);
 
   // SIRALAMA
   const sort = searchParams.get('sort');
@@ -92,4 +84,4 @@ export async function GET(req) {
 
   const result = await Product.aggregate(pipeline);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/meta/route.js
+++ b/src/app/api/meta/route.js
@@ -1,11 +1,10 @@
 // ✅ /api/meta/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await connectDB();
+export const GET = withDB(async () => {
 
   const [brands, features, categories] = await Promise.all([
     Product.distinct('brand', { brand: { $ne: null } }),
@@ -38,4 +37,4 @@ export async function GET() {
   ]);
 
   return NextResponse.json({ brands, features, categories });
-}
+});

--- a/src/app/api/nearby/route.js
+++ b/src/app/api/nearby/route.js
@@ -1,12 +1,11 @@
 // GET /api/nearby?lat=35.1&lng=33.9&radius=30
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
 
   const lat = parseFloat(searchParams.get('lat'));
@@ -47,4 +46,4 @@ export async function GET(req) {
   }));
 
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/price-history/route.js
+++ b/src/app/api/price-history/route.js
@@ -1,11 +1,10 @@
 // GET /api/price-history?group_slug=...
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('group_slug');
 
@@ -47,4 +46,4 @@ export async function GET(req) {
 
   const result = await Product.aggregate(pipeline);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/products/[id]/route.js
+++ b/src/app/api/products/[id]/route.js
@@ -1,11 +1,10 @@
 // src/app/api/products/[id]/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(_, { params }) {
-  await connectDB();
+export const GET = withDB(async (_, { params }) => {
   const { id } = params;
 
   try {
@@ -19,4 +18,4 @@ export async function GET(_, { params }) {
   } catch (err) {
     return NextResponse.json({ error: 'Geçersiz ID veya sunucu hatası.' }, { status: 400 });
   }
-}
+});

--- a/src/app/api/products/route.js
+++ b/src/app/api/products/route.js
@@ -1,11 +1,10 @@
 // ✅ /api/products/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
 
   const id = searchParams.get('id');
@@ -16,12 +15,8 @@ export async function GET(req) {
       : NextResponse.json({ error: 'Product not found' }, { status: 404 });
   }
 
-  const filters = {};
-  ['main_category', 'subcategory', 'category_item', 'brand', 'category_slug', 'group_slug'].forEach((key) => {
-    const val = searchParams.get(key);
-    if (val) filters[key] = val;
-  });
+  const filters = getFiltersFromQuery(searchParams);
 
   const products = await Product.find(filters).limit(100);
   return NextResponse.json(products);
-}
+});

--- a/src/app/api/recommendations/route.js
+++ b/src/app/api/recommendations/route.js
@@ -1,12 +1,11 @@
 // GET /api/recommendations?query=iphone&lat=35.1&lng=33.9
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
 
   const q = searchParams.get('query') || '';
@@ -38,4 +37,4 @@ export async function GET(req) {
     .select('group_title group_slug brand category_item price productUrl image');
 
   return NextResponse.json(products);
-}
+});

--- a/src/app/api/related-groups/route.js
+++ b/src/app/api/related-groups/route.js
@@ -1,11 +1,10 @@
 // src/app/api/related-groups/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('slug');
 
@@ -37,4 +36,4 @@ export async function GET(req) {
   ]);
 
   return NextResponse.json(similarGroups);
-}
+});

--- a/src/app/api/stats/route.js
+++ b/src/app/api/stats/route.js
@@ -1,11 +1,10 @@
 // src/app/api/stats/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET() {
-  await connectDB();
+export const GET = withDB(async () => {
 
   const [totalProducts, uniqueGroups, businesses, brands] = await Promise.all([
     Product.countDocuments(),
@@ -20,4 +19,4 @@ export async function GET() {
     businessCount: businesses.length,
     brandCount: brands.length
   });
-}
+});

--- a/src/app/api/suggestions/route.js
+++ b/src/app/api/suggestions/route.js
@@ -1,11 +1,10 @@
 // ✅ /api/suggestions/route.js
 
-import { connectDB } from '@/lib/mongodb';
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
+import { withDB } from '@/lib/api-utils';
 
-export async function GET(req) {
-  await connectDB();
+export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q');
 
@@ -55,4 +54,4 @@ export async function GET(req) {
   };
 
   return NextResponse.json(suggestions);
-}
+});

--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -1,0 +1,38 @@
+export function getFiltersFromQuery(searchParams) {
+  const filters = {};
+  const map = {
+    main: 'main_category',
+    main_category: 'main_category',
+    sub: 'subcategory',
+    subcategory: 'subcategory',
+    item: 'category_item',
+    category_item: 'category_item',
+    brand: 'brand',
+    category_slug: 'category_slug',
+    group_slug: 'group_slug'
+  };
+  Object.entries(map).forEach(([param, field]) => {
+    const val = searchParams.get(param);
+    if (val) filters[field] = val;
+  });
+  const q = searchParams.get('q');
+  if (q) {
+    filters.group_title = { $regex: q, $options: 'i' };
+  }
+  return filters;
+}
+
+import { connectDB } from './mongodb';
+import { NextResponse } from 'next/server';
+
+export function withDB(handler) {
+  return async (...args) => {
+    try {
+      await connectDB();
+      return await handler(...args);
+    } catch (err) {
+      console.error(err);
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add `getFiltersFromQuery` and `withDB` helpers
- refactor API routes to use the new helpers for DB connection, query parsing and error handling

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840743d955883329f57a980dc504909