### PR TITLE
Fix API fetch paths and add error catches

### DIFF
--- a/src/app/categories/page.js
+++ b/src/app/categories/page.js
@@ -21,7 +21,8 @@ export default function CategoriesPage() {
       .then((data) => {
         setCategories(data);
         setLoading(false);
-      });
+      })
+      .catch(() => setLoading(false));
   }, []);
 
   const getCategoryIcon = (categoryName) => {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -24,10 +24,12 @@ export default function HomePage() {
       .then((data) => {
         setSections(data);
         setLoading(false);
-      });
+      })
+      .catch(() => setLoading(false));
     fetch('/api/categories')
       .then((res) => res.json())
-      .then((data) => setCategories(data));
+      .then((data) => setCategories(data))
+      .catch(() => {});
   }, []);
 
   const filteredSections = sections.map(section => ({

--- a/src/app/search/page.js
+++ b/src/app/search/page.js
@@ -19,12 +19,13 @@ export default function SearchPage() {
   useEffect(() => {
     if (!query) return;
     setLoading(true);
-    fetch(`/api/products?search=${encodeURIComponent(query)}`)
+    fetch(`/api/search?query=${encodeURIComponent(query)}`)
       .then(res => res.json())
       .then(data => {
         setResults(data);
         setLoading(false);
-      });
+      })
+      .catch(() => setLoading(false));
   }, [query]);
 
   // Sadece belirli firmalar

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,9 +5,10 @@ export default function Footer() {
   const [categories, setCategories] = useState([]);
 
   useEffect(() => {
-    fetch('/api/business/categories')
+    fetch('/api/categories')
       .then((res) => res.json())
-      .then((data) => setCategories(data));
+      .then((data) => setCategories(data))
+      .catch(err => console.error('Failed to load footer categories', err));
   }, []);
 
   return (

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -25,9 +25,10 @@ export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
-    fetch('/api/categories/menu')
+    fetch('/api/categories?type=menu')
       .then(res => res.json())
-      .then(data => setMenu(data));
+      .then(data => setMenu(data))
+      .catch(err => console.error('Failed to load categories menu', err));
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update fetch URLs to the new API structure
- add missing `.catch` blocks for error handling

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and others)*

------
https://chatgpt.com/codex/tasks/task_e_6840745fd6988332b06c790e4c310ce8