### PR TITLE
Enhance fetch calls with error checks

### DIFF
--- a/src/app/categories/page.js
+++ b/src/app/categories/page.js
@@ -17,7 +17,10 @@ export default function CategoriesPage() {
 
   useEffect(() => {
     fetch('/api/categories')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load categories');
+        return res.json();
+      })
       .then((data) => {
         setCategories(data);
         setLoading(false);

--- a/src/app/category/[slug]/page.js
+++ b/src/app/category/[slug]/page.js
@@ -28,7 +28,10 @@ export default function CategoryPage() {
     
     setLoading(true);
     fetch(`/api/category/${categorySlug}`)
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) throw new Error('Category fetch failed');
+        return res.json();
+      })
       .then(data => {
         setProducts(Array.isArray(data) ? data : []);
         setLoading(false);

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -31,17 +31,22 @@ export default function LoginPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })
       });
-      
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Invalid credentials');
+      }
+
       const data = await res.json();
-      
+
       if (data.token) {
         localStorage.setItem('token', data.token);
         router.push('/');
       } else {
         setError('Geçersiz email veya şifre');
       }
-    } catch {
-      setError('Giriş yapılırken bir hata oluştu');
+    } catch (err) {
+      setError(err.message || 'Giriş yapılırken bir hata oluştu');
     } finally {
       setLoading(false);
     }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -20,14 +20,20 @@ export default function HomePage() {
 
   useEffect(() => {
     fetch('/api/grouped-by-category')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load sections');
+        return res.json();
+      })
       .then((data) => {
         setSections(data);
         setLoading(false);
       })
       .catch(() => setLoading(false));
     fetch('/api/categories')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load categories');
+        return res.json();
+      })
       .then((data) => setCategories(data))
       .catch(() => {});
   }, []);

--- a/src/app/register/page.js
+++ b/src/app/register/page.js
@@ -70,8 +70,8 @@ export default function RegisterPage() {
       } else {
         setError(data.error || 'Kayıt olurken bir hata oluştu');
       }
-    } catch {
-      setError('Kayıt olurken bir hata oluştu');
+    } catch (err) {
+      setError(err.message || 'Kayıt olurken bir hata oluştu');
     } finally {
       setLoading(false);
     }

--- a/src/app/search/page.js
+++ b/src/app/search/page.js
@@ -20,7 +20,10 @@ export default function SearchPage() {
     if (!query) return;
     setLoading(true);
     fetch(`/api/search?query=${encodeURIComponent(query)}`)
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) throw new Error('Search request failed');
+        return res.json();
+      })
       .then(data => {
         setResults(data);
         setLoading(false);

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -6,7 +6,10 @@ export default function Footer() {
 
   useEffect(() => {
     fetch('/api/categories')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load categories');
+        return res.json();
+      })
       .then((data) => setCategories(data))
       .catch(err => console.error('Failed to load footer categories', err));
   }, []);

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -26,7 +26,10 @@ export default function Navbar() {
 
   useEffect(() => {
     fetch('/api/categories?type=menu')
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to load categories menu');
+        return res.json();
+      })
       .then(data => setMenu(data))
       .catch(err => console.error('Failed to load categories menu', err));
   }, []);


### PR DESCRIPTION
## Summary
- add `res.ok` checks to all fetch requests
- handle errors in login and register pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68407dfdbba88332bd009ad067bd6dc2