### PR TITLE
Add auth middleware and protect API routes

### DIFF
--- a/src/app/api/businesses/route.js
+++ b/src/app/api/businesses/route.js
@@ -3,8 +3,13 @@
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
 import { withDB } from '@/lib/api-utils';
+import { authenticate } from '@/middleware/auth';
 
 export const GET = withDB(async (req) => {
+  const user = authenticate(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const { searchParams } = new URL(req.url);
 
   const lat = parseFloat(searchParams.get('lat'));

--- a/src/app/api/group/route.js
+++ b/src/app/api/group/route.js
@@ -5,8 +5,13 @@ import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
 import { withDB } from '@/lib/api-utils';
 import { formatGroup } from '@/lib/group';
+import { authenticate } from '@/middleware/auth';
 
 export const GET = withDB(async (req) => {
+  const user = authenticate(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('slug');
   const id = searchParams.get('id');

--- a/src/app/api/groups/route.js
+++ b/src/app/api/groups/route.js
@@ -4,8 +4,13 @@ import Product from '@/models/Product';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
 import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
+import { authenticate } from '@/middleware/auth';
 
 export const GET = withDB(async (req) => {
+  const user = authenticate(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const { searchParams } = new URL(req.url);
 
   // FİLTRELER

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,22 @@
+import { verifyToken } from '@/utils/auth';
+
+export function authenticate(req) {
+  const authHeader = req.headers.get('authorization');
+  let token = null;
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    token = authHeader.slice(7);
+  } else {
+    const cookieHeader = req.headers.get('cookie');
+    if (cookieHeader) {
+      const cookies = Object.fromEntries(
+        cookieHeader.split(';').map(c => {
+          const [k, ...v] = c.trim().split('=');
+          return [k, v.join('=')];
+        })
+      );
+      token = cookies.token;
+    }
+  }
+  if (!token) return null;
+  return verifyToken(token);
+}


### PR DESCRIPTION
## Summary
- add `authenticate` utility to check JWT from headers or cookies
- secure `groups`, `group`, and `businesses` API routes using the new middleware

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684099bcb8fc833298cd913b9080d805