### PR TITLE
Refactor API error handling

### DIFF
--- a/src/app/api/auth/register/route.js
+++ b/src/app/api/auth/register/route.js
@@ -1,7 +1,8 @@
 import User from '@/models/User';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
-import { withDB } from '@/lib/api-utils';
+import { withDB, errorResponse } from '@/lib/api-utils';
+import { NextResponse } from 'next/server';
 
 export const POST = withDB(async (req) => {
   try {
@@ -16,18 +17,14 @@ export const POST = withDB(async (req) => {
 
     const parsed = schema.safeParse(body);
     if (!parsed.success) {
-      return new Response(JSON.stringify({ error: parsed.error.errors }), {
-        status: 400,
-      });
+      return errorResponse(parsed.error.errors, 400);
     }
 
     const { email, password, userType } = parsed.data;
 
     const existingUser = await User.findOne({ email });
     if (existingUser) {
-      return new Response(JSON.stringify({ error: 'User already exists' }), {
-        status: 400,
-      });
+      return errorResponse('User already exists', 400);
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);
@@ -38,13 +35,9 @@ export const POST = withDB(async (req) => {
       userType,
     });
 
-    return new Response(JSON.stringify({ message: 'User created' }), {
-      status: 201,
-    });
+    return NextResponse.json({ message: 'User created' }, { status: 201 });
   } catch (error) {
     console.error('REGISTER ERROR:', error);
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-    });
+    return errorResponse('Internal server error', 500);
   }
 });

--- a/src/app/api/category/[slug]/route.js
+++ b/src/app/api/category/[slug]/route.js
@@ -1,12 +1,12 @@
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
-import { withDB } from '@/lib/api-utils';
+import { withDB, errorResponse } from '@/lib/api-utils';
 
 export const GET = withDB(async (_, { params }) => {
   const { slug } = params;
 
   if (!slug) {
-    return NextResponse.json({ error: 'slug parametresi gerekli' }, { status: 400 });
+    return errorResponse('slug parametresi gerekli', 400);
   }
 
   const products = await Product.find({ category_slug: slug }).sort({ price: 1 });

--- a/src/app/api/group/route.js
+++ b/src/app/api/group/route.js
@@ -3,7 +3,7 @@
 
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
-import { withDB } from '@/lib/api-utils';
+import { withDB, errorResponse } from '@/lib/api-utils';
 import { formatGroup } from '@/lib/group';
 
 export const GET = withDB(async (req) => {
@@ -14,12 +14,12 @@ export const GET = withDB(async (req) => {
 
   const query = slug ? { group_slug: slug } : id ? { group_id: id } : null;
   if (!query) {
-    return NextResponse.json({ error: 'slug veya id gerekli.' }, { status: 400 });
+    return errorResponse('slug veya id gerekli.', 400);
   }
 
   const products = await Product.find(query).sort({ price: 1 });
   if (!products.length) {
-    return NextResponse.json({ error: 'Ürün grubu bulunamadı.' }, { status: 404 });
+    return errorResponse('Ürün grubu bulunamadı.', 404);
   }
 
   const body = formatGroup(products);

--- a/src/app/api/nearby/route.js
+++ b/src/app/api/nearby/route.js
@@ -3,7 +3,7 @@
 import Product from '@/models/Product';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
-import { withDB } from '@/lib/api-utils';
+import { withDB, errorResponse } from '@/lib/api-utils';
 
 export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
@@ -13,7 +13,7 @@ export const GET = withDB(async (req) => {
   const maxDistance = parseFloat(searchParams.get('maxDistance')) || 50000; // metre
 
   if (isNaN(lat) || isNaN(lng)) {
-    return NextResponse.json({ error: 'lat ve lng parametreleri zorunludur.' }, { status: 400 });
+    return errorResponse('lat ve lng parametreleri zorunludur.', 400);
   }
 
   const nearbyBusinesses = await Business.aggregate([

--- a/src/app/api/price-history/route.js
+++ b/src/app/api/price-history/route.js
@@ -2,14 +2,14 @@
 
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
-import { withDB } from '@/lib/api-utils';
+import { withDB, errorResponse } from '@/lib/api-utils';
 
 export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('group_slug');
 
   if (!slug) {
-    return NextResponse.json({ error: 'group_slug gerekli.' }, { status: 400 });
+    return errorResponse('group_slug gerekli.', 400);
   }
 
   const pipeline = [

--- a/src/app/api/products/route.js
+++ b/src/app/api/products/route.js
@@ -2,7 +2,7 @@
 
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
-import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
+import { withDB, getFiltersFromQuery, errorResponse } from '@/lib/api-utils';
 
 export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
@@ -10,9 +10,7 @@ export const GET = withDB(async (req) => {
   const id = searchParams.get('id');
   if (id) {
     const product = await Product.findById(id);
-    return product
-      ? NextResponse.json(product)
-      : NextResponse.json({ error: 'Product not found' }, { status: 404 });
+    return product ? NextResponse.json(product) : errorResponse('Product not found', 404);
   }
 
   const filters = getFiltersFromQuery(searchParams);

--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -33,6 +33,10 @@ export function getFiltersFromQuery(searchParams) {
 import { connectDB } from './mongodb';
 import { NextResponse } from 'next/server';
 
+export function errorResponse(error, status = 500) {
+  return NextResponse.json({ error }, { status });
+}
+
 export function withDB(handler) {
   return async (...args) => {
     try {
@@ -40,7 +44,7 @@ export function withDB(handler) {
       return await handler(...args);
     } catch (err) {
       console.error(err);
-      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+      return errorResponse('Internal server error', 500);
     }
   };
 }


### PR DESCRIPTION
## Summary
- add `errorResponse` helper to unify error JSON
- use `errorResponse` in all API routes
- remove `new Response` usage in API handlers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint errors)*
- `node test.js` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68409b5bbc148332adb4eb62edd3462d