### PR TITLE
Add Zod query validation for API routes

### DIFF
--- a/src/app/api/groups/route.js
+++ b/src/app/api/groups/route.js
@@ -3,7 +3,8 @@
 import Product from '@/models/Product';
 import Business from '@/models/Business';
 import { NextResponse } from 'next/server';
-import { withDB, getFiltersFromQuery } from '@/lib/api-utils';
+import { withDB, getFiltersFromQuery, errorResponse } from '@/lib/api-utils';
+import { z } from 'zod';
 import { authenticate } from '@/middleware/auth';
 
 export const GET = withDB(async (req) => {
@@ -12,23 +13,54 @@ export const GET = withDB(async (req) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const { searchParams } = new URL(req.url);
+  const params = Object.fromEntries(searchParams.entries());
+
+  const schema = z.object({
+    main: z.string().optional(),
+    sub: z.string().optional(),
+    item: z.string().optional(),
+    brand: z.string().optional(),
+    category_slug: z.string().optional(),
+    group_slug: z.string().optional(),
+    q: z.string().optional(),
+    sort: z.enum(['minPrice_asc', 'maxPrice_desc', 'count_desc']).optional(),
+    lat: z
+      .preprocess(
+        (v) => (v === '' || v === undefined ? undefined : parseFloat(v)),
+        z.number().finite()
+      )
+      .optional(),
+    lng: z
+      .preprocess(
+        (v) => (v === '' || v === undefined ? undefined : parseFloat(v)),
+        z.number().finite()
+      )
+      .optional(),
+    radius: z
+      .preprocess(
+        (v) => (v === '' || v === undefined ? undefined : parseFloat(v)),
+        z.number().finite()
+      )
+      .default(30),
+  });
+
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return errorResponse(parsed.error.errors, 400);
+  }
+  const { sort, lat, lng, radius } = parsed.data;
 
   // FİLTRELER
-  const filters = getFiltersFromQuery(searchParams);
+  const filters = getFiltersFromQuery(new URLSearchParams(params));
 
   // SIRALAMA
-  const sort = searchParams.get('sort');
   let sortStage = {};
   if (sort === 'minPrice_asc') sortStage = { minPrice: 1 };
   if (sort === 'maxPrice_desc') sortStage = { maxPrice: -1 };
   if (sort === 'count_desc') sortStage = { count: -1 };
 
   // KONUM FİLTRESİ
-  const lat = parseFloat(searchParams.get('lat'));
-  const lng = parseFloat(searchParams.get('lng'));
-  const radius = parseFloat(searchParams.get('radius')) || 30; // km
-
-  const geoEnabled = !isNaN(lat) && !isNaN(lng);
+  const geoEnabled = typeof lat === 'number' && typeof lng === 'number';
 
   // AGGREGATION PIPELINE
   const pipeline = [];

--- a/src/app/api/products/route.js
+++ b/src/app/api/products/route.js
@@ -3,17 +3,48 @@
 import Product from '@/models/Product';
 import { NextResponse } from 'next/server';
 import { withDB, getFiltersFromQuery, errorResponse } from '@/lib/api-utils';
+import { z } from 'zod';
 
 export const GET = withDB(async (req) => {
   const { searchParams } = new URL(req.url);
+  const params = Object.fromEntries(searchParams.entries());
 
-  const id = searchParams.get('id');
+  const schema = z.object({
+    id: z.string().optional(),
+    main: z.string().optional(),
+    sub: z.string().optional(),
+    item: z.string().optional(),
+    brand: z.string().optional(),
+    category_slug: z.string().optional(),
+    group_slug: z.string().optional(),
+    q: z.string().optional(),
+    minPrice: z
+      .preprocess(
+        (v) => (v === '' || v === undefined ? undefined : parseFloat(v)),
+        z.number().finite()
+      )
+      .optional(),
+    maxPrice: z
+      .preprocess(
+        (v) => (v === '' || v === undefined ? undefined : parseFloat(v)),
+        z.number().finite()
+      )
+      .optional(),
+  });
+
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return errorResponse(parsed.error.errors, 400);
+  }
+
+  const { id } = parsed.data;
+
   if (id) {
     const product = await Product.findById(id);
     return product ? NextResponse.json(product) : errorResponse('Product not found', 404);
   }
 
-  const filters = getFiltersFromQuery(searchParams);
+  const filters = getFiltersFromQuery(new URLSearchParams(params));
 
   const products = await Product.find(filters).limit(100);
   return NextResponse.json(products);


### PR DESCRIPTION
## Summary
- validate query parameters in `groups`, `group`, `products` and `nearby` routes using Zod
- respond with 400 on failed validation

## Testing
- `npm run lint | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68409d3292f48332871c0f0722db653f