### PR TITLE
Add watchlist backend

### DIFF
--- a/src/app/api/watchlist/route.js
+++ b/src/app/api/watchlist/route.js
@@ -1,0 +1,53 @@
+import { connectDB } from '@/lib/mongodb';
+import WatchlistItem from '@/models/WatchlistItem';
+import { verifyToken } from '@/utils/auth';
+import { NextResponse } from 'next/server';
+
+function getUserFromRequest(req) {
+  const authHeader = req.headers.get('authorization');
+  const token = authHeader?.split(' ')[1];
+  if (!token) return null;
+  return verifyToken(token);
+}
+
+export async function GET(req) {
+  const user = getUserFromRequest(req);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  await connectDB();
+  const items = await WatchlistItem.find({ user: user.id || user._id }).lean();
+  return NextResponse.json(items);
+}
+
+export async function POST(req) {
+  const user = getUserFromRequest(req);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { groupSlug } = await req.json();
+  if (!groupSlug) {
+    return NextResponse.json({ error: 'groupSlug required' }, { status: 400 });
+  }
+
+  await connectDB();
+  const item = await WatchlistItem.findOneAndUpdate(
+    { user: user.id || user._id, groupSlug },
+    {},
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  return NextResponse.json(item, { status: 201 });
+}
+
+export async function DELETE(req) {
+  const user = getUserFromRequest(req);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { groupSlug } = await req.json();
+  if (!groupSlug) {
+    return NextResponse.json({ error: 'groupSlug required' }, { status: 400 });
+  }
+
+  await connectDB();
+  await WatchlistItem.deleteOne({ user: user.id || user._id, groupSlug });
+  return NextResponse.json({ message: 'Removed from watchlist' });
+}

--- a/src/models/WatchlistItem.js
+++ b/src/models/WatchlistItem.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const watchlistItemSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  groupSlug: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+watchlistItemSchema.index({ user: 1, groupSlug: 1 }, { unique: true });
+
+export default mongoose.models.WatchlistItem || mongoose.model('WatchlistItem', watchlistItemSchema);


### PR DESCRIPTION
## Summary
- add `WatchlistItem` mongoose model
- implement `/api/watchlist` route with GET/POST/DELETE handlers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a843ad0883328f85987a8943dd1d