### PR TITLE
Integrate new API endpoints

### DIFF
--- a/src/app/api/grouped-by-category/route.js
+++ b/src/app/api/grouped-by-category/route.js
@@ -1,0 +1,52 @@
+// ✅ Frontend'de Kullanım Yeri:
+// Ana sayfada kategorilere göre en ucuz ürün gruplarını bölümlü göstermek için
+// kullanılır. Her kategori için belirli sayıda ürün grubu döner.
+
+import Product from '@/models/Product';
+import { NextResponse } from 'next/server';
+import { withDB, getPagination } from '@/lib/api-utils';
+
+export const GET = withDB(async (req) => {
+  const { searchParams } = new URL(req.url);
+  // Her kategoriden kaç grup dönüleceği
+  const limit = parseInt(searchParams.get('limit') || '5', 10);
+
+  // Kategori başına en ucuz ürün gruplarını çek
+  const groups = await Product.aggregate([
+    { $match: { group_id: { $ne: null } } },
+    {
+      $group: {
+        _id: '$group_id',
+        group_title: { $first: '$group_title' },
+        group_slug: { $first: '$group_slug' },
+        image: { $first: '$image' },
+        price: { $min: '$price' },
+        businessName: { $first: '$businessName' },
+        category_slug: { $first: '$category_slug' },
+        category_title: { $first: '$category_item' },
+      }
+    },
+    { $sort: { price: 1 } }
+  ]);
+
+  const sectionsMap = new Map();
+  for (const g of groups) {
+    const slug = g.category_slug || 'other';
+    const title = g.category_title || 'Diğer';
+    if (!sectionsMap.has(slug)) {
+      sectionsMap.set(slug, { categorySlug: slug, categoryTitle: title, groups: [] });
+    }
+    const section = sectionsMap.get(slug);
+    if (section.groups.length < limit) {
+      section.groups.push({
+        title: g.group_title,
+        slug: g.group_slug,
+        image: g.image,
+        price: g.price,
+        businessName: g.businessName,
+      });
+    }
+  }
+
+  return NextResponse.json(Array.from(sectionsMap.values()));
+});

--- a/src/app/category/[slug]/page.js
+++ b/src/app/category/[slug]/page.js
@@ -27,13 +27,15 @@ export default function CategoryPage() {
     if (!categorySlug) return;
     
     setLoading(true);
-    fetch(`/api/category/${categorySlug}`)
+    fetch(`/api/grouped-products?category_slug=${encodeURIComponent(categorySlug)}`)
       .then(res => {
         if (!res.ok) throw new Error('Category fetch failed');
         return res.json();
       })
-      .then(data => {
-        setProducts(Array.isArray(data) ? data : []);
+      .then(body => {
+        const data = Array.isArray(body.data) ? body.data : [];
+        // data alanı varsa kullan, yoksa doğrudan gelen değeri kullan
+        setProducts(data.length ? data : Array.isArray(body) ? body : []);
         setLoading(false);
       })
       .catch(() => {
@@ -105,7 +107,7 @@ export default function CategoryPage() {
               Bu Kategoride Ürün Bulunamadı
             </h3>
             <p className="text-gray-500 dark:text-gray-500 text-lg mb-6">
-              "{categoryTitle}" kategorisinde henüz ürün bulunmamaktadır.
+              {categoryTitle} kategorisinde henüz ürün bulunmamaktadır.
             </p>
             <Link
               href="/categories"

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,6 @@
 import { AuthProvider } from '@/context/AuthContext';
 import Navbar from '@components/Navbar';
+import Link from 'next/link';
 import '@app/globals.css';
 
 export const metadata = {
@@ -47,10 +48,10 @@ export default function RootLayout({ children }) {
                   <div>
                     <h3 className="font-semibold text-white mb-4">Hızlı Linkler</h3>
                     <ul className="space-y-2 text-gray-300">
-                      <li><a href="/" className="hover:text-orange-400 transition-colors">Ana Sayfa</a></li>
-                      <li><a href="/categories" className="hover:text-orange-400 transition-colors">Kategoriler</a></li>
-                      <li><a href="/search?q=bilgisayar" className="hover:text-orange-400 transition-colors">Popüler Aramalar</a></li>
-                      <li><a href="/about" className="hover:text-orange-400 transition-colors">Hakkımızda</a></li>
+                      <li><Link href="/" className="hover:text-orange-400 transition-colors">Ana Sayfa</Link></li>
+                      <li><Link href="/categories" className="hover:text-orange-400 transition-colors">Kategoriler</Link></li>
+                      <li><Link href="/search?q=bilgisayar" className="hover:text-orange-400 transition-colors">Popüler Aramalar</Link></li>
+                      <li><Link href="/about" className="hover:text-orange-400 transition-colors">Hakkımızda</Link></li>
                     </ul>
                   </div>
 
@@ -58,10 +59,10 @@ export default function RootLayout({ children }) {
                   <div>
                     <h3 className="font-semibold text-white mb-4">Destek</h3>
                     <ul className="space-y-2 text-gray-300">
-                      <li><a href="/help" className="hover:text-orange-400 transition-colors">Yardım Merkezi</a></li>
-                      <li><a href="/contact" className="hover:text-orange-400 transition-colors">İletişim</a></li>
-                      <li><a href="/privacy" className="hover:text-orange-400 transition-colors">Gizlilik</a></li>
-                      <li><a href="/terms" className="hover:text-orange-400 transition-colors">Kullanım Şartları</a></li>
+                      <li><Link href="/help" className="hover:text-orange-400 transition-colors">Yardım Merkezi</Link></li>
+                      <li><Link href="/contact" className="hover:text-orange-400 transition-colors">İletişim</Link></li>
+                      <li><Link href="/privacy" className="hover:text-orange-400 transition-colors">Gizlilik</Link></li>
+                      <li><Link href="/terms" className="hover:text-orange-400 transition-colors">Kullanım Şartları</Link></li>
                     </ul>
                   </div>
                 </div>
@@ -72,7 +73,7 @@ export default function RootLayout({ children }) {
                     © {new Date().getFullYear()} BizLinker. Tüm hakları saklıdır.
                   </p>
                   <div className="flex items-center gap-4 mt-4 md:mt-0">
-                    <span className="text-gray-400 text-sm">Türkiye'nin fiyat karşılaştırma platformu</span>
+                    <span className="text-gray-400 text-sm">T&uuml;rkiye&apos;nin fiyat karşılaştırma platformu</span>
                   </div>
                 </div>
               </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -15,6 +15,7 @@ import {
 export default function HomePage() {
   const [sections, setSections] = useState([]);
   const [categories, setCategories] = useState([]);
+  const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
 
@@ -35,6 +36,11 @@ export default function HomePage() {
         return res.json();
       })
       .then((data) => setCategories(data))
+      .catch(() => {});
+
+    fetch('/api/stats')
+      .then(res => (res.ok ? res.json() : null))
+      .then(data => setStats(data))
       .catch(() => {});
   }, []);
 
@@ -111,16 +117,16 @@ export default function HomePage() {
           {/* Quick stats */}
           <div className="grid grid-cols-2 md:grid-cols-3 gap-6 max-w-xl mx-auto">
             <div className="bg-white/60 dark:bg-black/20 backdrop-blur-sm rounded-xl p-4 border border-white/20">
-              <div className="text-2xl font-bold text-orange-600">3</div>
+              <div className="text-2xl font-bold text-orange-600">{stats?.businessCount ?? '-'}</div>
               <div className="text-sm text-gray-600 dark:text-gray-400">Firma</div>
             </div>
             <div className="bg-white/60 dark:bg-black/20 backdrop-blur-sm rounded-xl p-4 border border-white/20">
-              <div className="text-2xl font-bold text-blue-600">1000+</div>
+              <div className="text-2xl font-bold text-blue-600">{stats?.totalProducts ?? '-'}</div>
               <div className="text-sm text-gray-600 dark:text-gray-400">Ürün</div>
             </div>
             <div className="bg-white/60 dark:bg-black/20 backdrop-blur-sm rounded-xl p-4 border border-white/20 col-span-2 md:col-span-1">
-              <div className="text-2xl font-bold text-green-600">%50</div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Tasarruf</div>
+              <div className="text-2xl font-bold text-green-600">{stats ? `%${stats.brandCount}` : '-'}</div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">Marka</div>
             </div>
           </div>
         </div>

--- a/src/app/register/page.js
+++ b/src/app/register/page.js
@@ -95,9 +95,9 @@ export default function RegisterPage() {
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
               Hesap Oluşturun
             </h1>
-            <p className="text-gray-600 dark:text-gray-400">
-              BizLinker'a katılın ve en iyi fiyatları keşfedin
-            </p>
+              <p className="text-gray-600 dark:text-gray-400">
+                BizLinker&apos;a katılın ve en iyi fiyatları keşfedin
+              </p>
           </div>
 
           {/* Register Form */}

--- a/src/app/search/page.js
+++ b/src/app/search/page.js
@@ -77,7 +77,7 @@ export default function SearchPage() {
             </div>
             
             <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
-              "<span className="text-orange-600">{query}</span>" için
+              <span className="text-orange-600">{query}</span> için
               <br />
               <span className="text-2xl md:text-3xl bg-gradient-to-r from-orange-600 to-blue-600 bg-clip-text text-transparent">
                 Firma Karşılaştırma
@@ -107,7 +107,7 @@ export default function SearchPage() {
               Sonuç Bulunamadı
             </h3>
             <p className="text-gray-500 dark:text-gray-500 text-lg mb-6">
-              "{query}" için belirlediğimiz firmalarda ürün bulunamadı
+              {query} için belirlediğimiz firmalarda ürün bulunamadı
             </p>
             <div className="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 max-w-md mx-auto">
               <h4 className="font-semibold text-blue-900 dark:text-blue-200 mb-2">İpucu:</h4>


### PR DESCRIPTION
## Summary
- add grouped-by-category API for homepage sections
- switch category page to new grouped-products API
- fetch site stats in homepage
- fix ESLint issues and use Next.js `Link` in layout
- fix unescaped strings in Turkish pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841c71a43f08332907389af6dcab1f1